### PR TITLE
adding env variable key for TINYMCE

### DIFF
--- a/src/components/RTE.jsx
+++ b/src/components/RTE.jsx
@@ -13,7 +13,7 @@ export default function RTE({ name, control, label, defaultValue = "" }) {
                 control={control}
                 render={({ field: { onChange } }) => (
                     <Editor
-                        apiKey='tnr7d2xleel5c3jsy0t01t5fono94zbjuzmcnjtnc73zesf1'
+                        apiKey={import.meta.env.VITE_APPWRITE_API_KEY}
                         initialValue={defaultValue}
                         init={{
                             initialValue: defaultValue,

--- a/src/conf/conf.js
+++ b/src/conf/conf.js
@@ -4,6 +4,7 @@ const conf = {
     appwriteDatabaseId: String(import.meta.env.VITE_APPWRITE_DATABASE_ID),
     appwriteCollectionId: String(import.meta.env.VITE_APPWRITE_COLLECTION_ID),
     appwriteBucketId: String(import.meta.env.VITE_APPWRITE_BUCKET_ID),
+    appwriteApiKey: String(import.meta.env.VITE_APPWRITE_API_KEY),
 
 }
 
@@ -11,5 +12,5 @@ const conf = {
 // console.log("Appwrite Project ID:", conf.appwriteProjectId);
 // console.log("Appwrite Database ID:", conf.appwriteDatabaseId);
 // console.log("Appwrite Collection ID:", conf.appwriteCollectionId);
-// console.log("Appwrite Bucket ID:", conf.appwriteBucketId);
+console.log("Appwrite API Key :", conf.appwriteApiKey);
 export default conf


### PR DESCRIPTION
Now TINYMCE require api key for authentication and not qallow to freely use it, so we required api key for that
This pull request includes changes to improve the security and configuration management of the application by using environment variables for sensitive information. The most important changes include updating the API key usage in the `RTE` component and adding the API key to the configuration file.

Security improvements:

* [`src/components/RTE.jsx`](diffhunk://#diff-bbb553a68226a2bda4cd001b74cc747fd37235a1b59da1f576fdc36e1a7d8a89L16-R16): Changed the `apiKey` to use the value from `import.meta.env.VITE_APPWRITE_API_KEY` instead of a hardcoded string.

Configuration management:

* [`src/conf/conf.js`](diffhunk://#diff-a2d1e8af4fb79cc3a5671a60688733c8f14cedb2d793f276942e398293959609R7-R15): Added `appwriteApiKey` to the configuration object and logged the API key for debugging purposes.